### PR TITLE
Change default listen directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,39 @@ The following lists all the class parameters the bacula class accepts as well as
     console_template              bacula_console_template         The ERB template to use for configuring the bconsole instead of the one included with the module
     use_console                   bacula_use_console              Whether to configure a console resource on the director
     console_password              bacula_console_password         The password to use for the console resource on the director
+    director_listen               bacula_director_listen          Hash of addresses and ports to have bacula director listening on
+    client_listen                 bacula_client_listen            Hash of addresses and ports to have bacula file daemon listening on
+    storage_listen                bacula_storage_listen           Hash of addresses and ports to have bacula storage daemon listening on
+
+Listening on non-default address/port
+=====================================
+
+To have bacula director, file daemon or storage daemon listening on non-default address and port, set the director_listen, client_listen or storage_listen respectivly
+
+```puppet
+  $dir_listen = {
+    'ipv4' => [
+      {addr => '0.0.0.0', port => '9101'},
+      {addr => '127.0.0.1', port => '9108'}
+    ],
+    'ipv6' => [
+      {addr => '::', port => '9101'}
+    ]
+  }
+
+  class { 'bacula':
+    is_storage        => true,
+    is_director       => true,
+    is_client         => true,
+    director_listen   => $dir_listen,
+    manage_console    => true,
+    director_password => 'XXXXXXXXX',
+    console_password  => 'XXXXXXXXX',
+    director_server   => 'bacula.domain.com',
+    mail_to           => 'bacula-admin@domain.com',
+    storage_server    => 'bacula.domain.com',
+  }
+```
 
 CLIENTS
 =======

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -5,6 +5,8 @@
 # Parameters:
 #   $director_server:
 #       The FQDN of the bacula director
+#   $listen:
+#       Hash of addresses and ports to have bacula file daemon listening on
 #   $director_password:
 #       The director's password
 #   $client_package:
@@ -24,6 +26,7 @@
 # }
 class bacula::client(
     $director_server,
+    $listen,
     $director_password,
     $client_package
   ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -129,6 +129,24 @@ class bacula::config {
     default => $::bacula_director_server,
   }
 
+  if $::bacula_director_listen == undef {
+    $director_listen = { 'ipv4' => [{ addr => '0.0.0.0', port => '9101' }]}
+  } else {
+    $director_listen = $::bacula_director_listen
+  }
+
+  if $::bacula_client_listen == undef {
+    $client_listen = { 'ipv4' => [{ addr => '0.0.0.0', port => '9102' }] }
+  } else {
+    $client_listen = $::bacula_client_listen
+  }
+
+  if $::bacula_storage_listen == undef {
+    $storage_listen = { 'ipv4' => [{ addr => '0.0.0.0', port => '9103' }] }
+  } else {
+    $storage_listen = $::bacula_storage_listen
+  }
+
   $storage_server = $::bacula_storage_server ? {
     undef   => '',
     default => $::bacula_storage_server,

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -5,6 +5,8 @@
 # Parameters:
 #   $server:
 #     The FQDN of the bacula director
+#   $listen:
+#     Hash of addresses and ports to have bacula director listening on
 #   $password:
 #     The password of the director
 #   $db_backend:
@@ -38,6 +40,7 @@
 # }
 class bacula::director(
     $server,
+    $listen,
     $password,
     $db_backend,
     $db_user,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,12 @@
 #     The console's password
 #   $director_server
 #     The FQDN of the bacula director
+#   $director_listen
+#     Hash of addresses and ports to have bacula director listening on
+#   $client_listen
+#     Hash of addresses and ports to have bacula file daemon listening on
+#   $storage_listen
+#     Hash of addresses and ports to have bacula storage daemon listening on
 #   $storage_server
 #     The FQDN of the storage server
 #   $manage_console
@@ -112,6 +118,9 @@ class bacula(
     $director_password       = $bacula::config::director_password,
     $console_password        = $bacula::config::console_password,
     $director_server         = $bacula::config::bacula_director_server,
+    $director_listen         = $bacula::config::director_listen,
+    $client_listen           = $bacula::config::client_listen,
+    $storage_listen          = $bacula::config::storage_listen,
     $storage_server          = $bacula::config::bacula_storage_server,
     $manage_console          = $bacula::config::safe_manage_console,
     $console_package         = $bacula::config::console_package,
@@ -173,6 +182,7 @@ class bacula(
     class { 'bacula::director':
       db_backend       => $db_backend,
       server           => $director_server,
+      listen           => $director_listen,
       storage_server   => $storage_server,
       password         => $director_password,
       mysql_package    => $director_mysql_package,
@@ -196,6 +206,7 @@ class bacula(
     class { 'bacula::storage':
       db_backend        => $db_backend,
       director_server   => $director_server,
+      listen            => $storage_listen,
       director_password => $director_password,
       storage_server    => $storage_server,
       mysql_package     => $storage_mysql_package,
@@ -210,6 +221,7 @@ class bacula(
   if $is_client {
     class { 'bacula::client': 
       director_server   => $director_server,
+      listen            => $client_listen,
       director_password => $director_password,
       client_package    => $client_package,
       require           => Class['bacula::common'],

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -7,6 +7,8 @@
 #     The database backend to use. (Currently only supports sqlite)
 #   $director_server:
 #     The FQDN of the bacula director
+#   $listen:
+#     Hash of addresses and ports to have bacula storage daemon listening on
 #   $director_password:
 #     The director's password
 #   $storage_server:
@@ -42,6 +44,7 @@ class bacula::storage(
     $director_server,
     $director_password,
     $storage_server,
+    $listen,
     $storage_package = '',
     $mysql_package,
     $sqlite_package,

--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -16,7 +16,7 @@ Director {
   DirAddresses = {
     <%- scope.lookupvar('bacula::director::listen').each_pair do |family, listen| -%>
     <%- listen.each do |hash| -%>
-    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; <%- if hash.has_key?('port') -%>port = <%= hash['port'] -%> ; <%- end -%>}
     <%- end -%>
     <%- end -%>
   }

--- a/templates/bacula-dir.conf.erb
+++ b/templates/bacula-dir.conf.erb
@@ -13,6 +13,13 @@ Director {
   Maximum Concurrent Jobs = 5
   Password = "<%= password -%>"
   Messages = "<%= director_name -%>:messages:daemon"
+  DirAddresses = {
+    <%- scope.lookupvar('bacula::director::listen').each_pair do |family, listen| -%>
+    <%- listen.each do |hash| -%>
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%- end -%>
+    <%- end -%>
+  }
 }
 
 # This is where the catalog information will be stored (basically

--- a/templates/bacula-fd.conf.erb
+++ b/templates/bacula-fd.conf.erb
@@ -16,6 +16,13 @@ FileDaemon {
   Working Directory = /var/lib/bacula
   PID Directory = /var/run/bacula
   Maximum Concurrent Jobs = 3
+  FDAddresses = {
+    <%- scope.lookupvar('bacula::client::listen').each_pair do |family, listen| -%>
+    <%- listen.each do |hash| -%>
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%- end -%>
+    <%- end -%>
+  }
 }
 
 # Finally, set where the messages are going to go

--- a/templates/bacula-fd.conf.erb
+++ b/templates/bacula-fd.conf.erb
@@ -19,7 +19,7 @@ FileDaemon {
   FDAddresses = {
     <%- scope.lookupvar('bacula::client::listen').each_pair do |family, listen| -%>
     <%- listen.each do |hash| -%>
-    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; <%- if hash.has_key?('port') -%>port = <%= hash['port'] -%> ; <%- end -%>}
     <%- end -%>
     <%- end -%>
   }

--- a/templates/bacula-sd.conf.erb
+++ b/templates/bacula-sd.conf.erb
@@ -25,7 +25,7 @@ Storage {
   SDAddresses = {
     <%- scope.lookupvar('bacula::storage::listen').each_pair do |family, listen| -%>
     <%- listen.each do |hash| -%>
-    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; <%- if hash.has_key?('port') -%>port = <%= hash['port'] -%> ; <%- end -%>}
     <%- end -%>
     <%- end -%>
   }

--- a/templates/bacula-sd.conf.erb
+++ b/templates/bacula-sd.conf.erb
@@ -22,6 +22,13 @@ Storage {
   Working Directory = "/var/lib/bacula"
   PID Directory = "/var/run/bacula"
   Maximum Concurrent Jobs = 20
+  SDAddresses = {
+    <%- scope.lookupvar('bacula::storage::listen').each_pair do |family, listen| -%>
+    <%- listen.each do |hash| -%>
+    <%= family -%> = { addr = <%= hash['addr'] -%> ; port = <%= hash['port'] -%> ; }
+    <%- end -%>
+    <%- end -%>
+  }
 }
 
 # Also configure access for something to monitor this Storage Daemon


### PR DESCRIPTION
Bacula defaults to listen on any IPv4 using standard bacula ports, these changes add support to listen on specific IPv4 or IPv6 addresses and custom port numbers.
This is necessary in IPv6-only environments or when IPv6 is simply preferred over IPv4.