### PR TITLE
Pull postgresql redhat

### DIFF
--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -38,7 +38,10 @@ class bacula::common(
 
   if $manage_db_tables {
     exec { 'make_db_tables':
-      command     => "/usr/lib/bacula/make_bacula_tables ${db_parameters}",
+      command     => $::osfamily ? {
+        'Redhat' => "/usr/libexec/bacula/make_bacula_tables ${db_parameters}",
+        default  => "/usr/lib/bacula/make_bacula_tables ${db_parameters}",
+      },
       refreshonly => true,
     }
   }

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -32,8 +32,9 @@ class bacula::common(
   }
 
   $db_parameters = $db_backend ? {
-    'sqlite' => '',
-    'mysql'  => "--host=${db_host} --user=${db_user} --password=${db_password} --port=${db_port} --database=${db_database}",
+    'sqlite'     => '',
+    'mysql'      => "--host=${db_host} --user=${db_user} --password=${db_password} --port=${db_port} --database=${db_database}",
+    'postgresql' => "--host=${db_host} --user=${db_user} --password=${db_password} --port=${db_port} --database=${db_database}",
   }
 
   if $manage_db_tables {
@@ -59,6 +60,23 @@ class bacula::common(
           },
           require => defined(Class['mysql::server']) ? {
             true  => Class['mysql::server'],
+            false => undef,
+          }
+        }
+      }
+
+      'postgresql': {
+        include postgresql::server
+
+        postgresql::server::db { $db_database:
+          user     => $db_user,
+          password => $db_password,
+          notify   => $manage_db_tables ? {
+            true  => Exec['make_db_tables'],
+            false => undef,
+          },
+          require => defined(Class['postgresql::server']) ? {
+            true  => Class['postgresql::server'],
             false => undef,
           },
         }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -159,6 +159,16 @@ class bacula::config {
     default => $::bacula_storage_mysql_package,
   }
 
+  $director_postgresql_package  = $::bacula_director_postgresql_package ? {
+    undef   => 'bacula-director-postgresql',
+    default => $::bacula_director_postgresql_package,
+  }
+
+  $storage_postgresql_package  = $::bacula_storage_postgresql_package ? {
+    undef   => 'bacula-sd-postgresql',
+    default => $::bacula_storage_postgresql_package,
+  }
+
   $director_sqlite_package = $::bacula_director_sqlite_package ? {
     undef   => 'bacula-director-sqlite3',
     default => $::bacula_director_sqlite_package,
@@ -190,8 +200,11 @@ class bacula::config {
   }
  
   $db_port = $::bacula_db_port ? {
-    undef   => '3306',
-    default => $::bacula_db_user,
+    undef   => $bacula_db_backend ? {
+      'postgresql' => '5432',
+      default      => '3306',
+    },
+    default => $::bacula_db_port,
   }
 
   $db_password = $::bacula_db_password ? {

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -15,6 +15,8 @@
 #     The name of the package that installs the director (Optional)
 #   $mysql_package:
 #     The name of the package that installs the mysql support for the director
+#   $postgresql_package:
+#     The name of the package that installs the postgresql support for the director
 #   $sqlite_package:
 #     The name of the package that installs the sqlite support for the director
 #   $template:
@@ -48,6 +50,7 @@ class bacula::director(
     $storage_server,
     $director_package = '',
     $mysql_package,
+    $postgresql_package,
     $mail_to,
     $sqlite_package,
     $template = 'bacula/bacula-dir.conf.erb',
@@ -75,8 +78,9 @@ class bacula::director(
   # The given backend is validated in the bacula::config::validate class
   # before this code is reached.
   $db_package = $db_backend ? {
-    'mysql'  => $mysql_package,
-    'sqlite' => $sqlite_package,
+    'mysql'      => $mysql_package,
+    'postgresql' => $postgres_package,
+    'sqlite'     => $sqlite_package,
   }
   
   if $director_package {

--- a/manifests/director.pp
+++ b/manifests/director.pp
@@ -123,6 +123,10 @@ class bacula::director(
 
   # Register the Service so we can manage it through Puppet
   service { 'bacula-director':
+    name       => $::osfamily ? {
+      'Redhat' => 'bacula-dir',
+      default  => 'bacula-director',
+    },
     enable     => true,
     ensure     => running,
     hasstatus  => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,11 @@
 #   $director_mysql_package
 #     The name of the package to install the director's mysql functionality
 #   $storage_mysql_package
-#     The name of the package to install the storage's sqlite functionality
+#     The name of the package to install the storage's mysql functionality
+#   $director_postgresql_package
+#     The name of the package to install the director's postgresql functionality
+#   $storage_postgresql_package
+#     The name of the package to install the storage's postgresql functionality
 #   $director_template
 #     The ERB template to use for configuring the director instead of the one included with the module
 #   $storage_template
@@ -97,38 +101,40 @@
 #   clients           => $clients,
 # }
 class bacula(
-    $db_backend              = $bacula::config::db_backend,
-    $db_user                 = $bacula::config::db_user,
-    $db_password             = $bacula::config::db_password,
-    $db_host                 = $bacula::config::db_host,
-    $db_database             = $bacula::config::db_database,
-    $db_port                 = $bacula::config::db_port,
-    $manage_db               = $bacula::config::safe_manage_db,
-    $manage_db_tables        = $bacula::config::safe_manage_db_tables,
-    $mail_to                 = $bacula::config::mail_to,
-    $is_director             = $bacula::config::safe_is_director, 
-    $is_client               = $bacula::config::safe_is_client,
-    $is_storage              = $bacula::config::safe_is_storage,
-    $director_password       = $bacula::config::director_password,
-    $console_password        = $bacula::config::console_password,
-    $director_server         = $bacula::config::bacula_director_server,
-    $storage_server          = $bacula::config::bacula_storage_server,
-    $manage_console          = $bacula::config::safe_manage_console,
-    $console_package         = $bacula::config::console_package,
-    $manage_bat              = $bacula::config::safe_manage_bat,
-    $director_package        = $bacula::config::director_package,
-    $storage_package         = $bacula::config::storage_package,
-    $client_package          = $bacula::config::client_package,
-    $director_sqlite_package = $bacula::config::director_sqlite_package,
-    $storage_sqlite_package  = $bacula::config::storage_sqlite_package,
-    $director_mysql_package  = $bacula::config::director_mysql_package,
-    $storage_mysql_package   = $bacula::config::storage_mysql_package,
-    $director_template       = $bacula::config::director_template,
-    $storage_template        = $bacula::config::storage_template,
-    $console_template        = $bacula::config::console_template,
-    $use_console             = $bacula::config::safe_use_console,
-    $console_password        = $bacula::config::console_password,
-    $clients                 = {}
+    $db_backend                  = $bacula::config::db_backend,
+    $db_user                     = $bacula::config::db_user,
+    $db_password                 = $bacula::config::db_password,
+    $db_host                     = $bacula::config::db_host,
+    $db_database                 = $bacula::config::db_database,
+    $db_port                     = $bacula::config::db_port,
+    $manage_db                   = $bacula::config::safe_manage_db,
+    $manage_db_tables            = $bacula::config::safe_manage_db_tables,
+    $mail_to                     = $bacula::config::mail_to,
+    $is_director                 = $bacula::config::safe_is_director,
+    $is_client                   = $bacula::config::safe_is_client,
+    $is_storage                  = $bacula::config::safe_is_storage,
+    $director_password           = $bacula::config::director_password,
+    $console_password            = $bacula::config::console_password,
+    $director_server             = $bacula::config::bacula_director_server,
+    $storage_server              = $bacula::config::bacula_storage_server,
+    $manage_console              = $bacula::config::safe_manage_console,
+    $console_package             = $bacula::config::console_package,
+    $manage_bat                  = $bacula::config::safe_manage_bat,
+    $director_package            = $bacula::config::director_package,
+    $storage_package             = $bacula::config::storage_package,
+    $client_package              = $bacula::config::client_package,
+    $director_sqlite_package     = $bacula::config::director_sqlite_package,
+    $storage_sqlite_package      = $bacula::config::storage_sqlite_package,
+    $director_mysql_package      = $bacula::config::director_mysql_package,
+    $storage_mysql_package       = $bacula::config::storage_mysql_package,
+    $director_postgresql_package = $bacula::config::director_postgresql_package,
+    $storage_postgresql_package  = $bacula::config::storage_postgresql_package,
+    $director_template           = $bacula::config::director_template,
+    $storage_template            = $bacula::config::storage_template,
+    $console_template            = $bacula::config::console_template,
+    $use_console                 = $bacula::config::safe_use_console,
+    $console_password            = $bacula::config::console_password,
+    $clients                     = {}
   ) inherits bacula::config {
     
 
@@ -171,39 +177,41 @@ class bacula(
   
   if $is_director {
     class { 'bacula::director':
-      db_backend       => $db_backend,
-      server           => $director_server,
-      storage_server   => $storage_server,
-      password         => $director_password,
-      mysql_package    => $director_mysql_package,
-      sqlite_package   => $director_sqlite_package,
-      director_package => $director_package,
-      mail_to          => $mail_to,
-      template         => $director_template,
-      use_console      => $use_console,
-      console_password => $console_password,
-      db_user          => $db_user,
-      db_password      => $db_password,
-      db_host          => $db_host,
-      db_port          => $db_port,
-      db_database      => $db_database,
-      require          => Class['bacula::common'],
-      clients          => $clients,
+      db_backend         => $db_backend,
+      server             => $director_server,
+      storage_server     => $storage_server,
+      password           => $director_password,
+      postgresql_package => $director_postgresql_package,
+      mysql_package      => $director_mysql_package,
+      sqlite_package     => $director_sqlite_package,
+      director_package   => $director_package,
+      mail_to            => $mail_to,
+      template           => $director_template,
+      use_console        => $use_console,
+      console_password   => $console_password,
+      db_user            => $db_user,
+      db_password        => $db_password,
+      db_host            => $db_host,
+      db_port            => $db_port,
+      db_database        => $db_database,
+      require            => Class['bacula::common'],
+      clients            => $clients,
     }
   }
 
   if $is_storage {
     class { 'bacula::storage':
-      db_backend        => $db_backend,
-      director_server   => $director_server,
-      director_password => $director_password,
-      storage_server    => $storage_server,
-      mysql_package     => $storage_mysql_package,
-      sqlite_package    => $storage_sqlite_package,
-      storage_package   => $storage_package,
-      console_password  => $console_password,
-      template          => $storage_template,
-      require           => Class['bacula::common'],
+      db_backend         => $db_backend,
+      director_server    => $director_server,
+      director_password  => $director_password,
+      storage_server     => $storage_server,
+      postgresql_package => $storage_postgresql_package,
+      mysql_package      => $storage_mysql_package,
+      sqlite_package     => $storage_sqlite_package,
+      storage_package    => $storage_package,
+      console_password   => $console_password,
+      template           => $storage_template,
+      require            => Class['bacula::common'],
     }
   }
 

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -15,6 +15,8 @@
 #     The package name to install the storage daemon (Optional)
 #   $mysql_package:
 #     The package name to install the storage daemon mysql component
+#   $postgresql_package:
+#     The package name to install the storage daemon postgresql component
 #   $sqlite_package:
 #     The package name to install the storage daemon sqlite component
 #   $console_password:
@@ -44,6 +46,7 @@ class bacula::storage(
     $storage_server,
     $storage_package = '',
     $mysql_package,
+    $postgresql_package,
     $sqlite_package,
     $console_password,
     $template = 'bacula/bacula-sd.conf.erb'
@@ -55,8 +58,9 @@ class bacula::storage(
   $director_name = $director_name_array[0]
 
   $db_package = $db_backend ? {
-    'mysql'  => $mysql_package,
-    'sqlite' => $sqlite_package,
+    'mysql'    => $mysql_package,
+    'sqlite'   => $sqlite_package,
+    'postgresql' => $postgresql_package,
   }
 
   # This is necessary because the bacula-common package will


### PR DESCRIPTION
This patch series adds postgresql support and support for RHEL 6 based distros with bacula 5.0.x .  

This fixes issue https://github.com/puppetlabs/puppetlabs-bacula/issues/23 .