### PR TITLE
first fast quick n dirty fix #1 for postgresql support with a redhat

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2014-10-04 - Patrick Emer <pemer@afdata.de> - 0.0.3
+ - Support for Redhat/Centos distributions
+ - Support for postgresql database catalog 
+
 2011-12-15 - Carl Caum <carl@puppetlabs.com> - 0.0.1
  - Support multiple DB backends
  - Support Managing databases through 3rd party modules

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppetlabs-bacula'
-version '0.0.2'
+version '0.0.3'
 source 'http://github.com/puppetlabs/puppetlabs-bacula'
 author 'Puppet Labs'
 license 'Apache'
@@ -10,4 +10,5 @@ project_page 'http://github.com/puppetlabs/puppetlabs-bacula'
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 2.2.0'
 dependency 'puppetlabs/mysql',  '>= 0.0.1'
+dependency 'puppetlabs/postgresql',  '>= 0.0.1'
 dependency 'puppetlabs/sqlite', '>= 0.0.1'

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ REQUIREMENTS
    Declare the mysql::server class to set up a mysql server on the bacula director node and set `manage_db` to true to have bacula manage the mysql database.
  * Puppetlabs/sqlite module.  Can be obtained here http://forge.puppetlabs.com/puppetlabs/sqlite or with the command `puppet-module install puppetlabs/sqlite`
    Declare the mysql::sqlite class so it's available for the bacula class to use.
-
+ * Puppetlabs/postgresql module.  Can be obtained here http://forge.puppetlabs.com/puppetlabs/postgresql or with the command `puppet-module install puppetlabs/postgresql`
+   Declare the postgresql::server class to set up a postgresql server on the bacula director node and set `manage_db` to true to have bacula manage the postgresql database.
 
 CONFIGURATION
 =============
@@ -108,7 +109,9 @@ The following lists all the class parameters the bacula class accepts as well as
     director_sqlite_package       bacula_director_sqlite_package  The name of the package to install the director's sqlite functionality
     storage_sqlite_package        bacula_storage_sqlite_package   The name of the package to install the storage daemon's sqlite functionality
     director_mysql_package        bacula_director_mysql_package   The name of the package to install the director's mysql functionality
-    storage_mysql_package         bacula_storage_mysql_package    The name of the package to install the storage's sqlite functionality
+    storage_mysql_package         bacula_storage_mysql_package    The name of the package to install the storage's mysql functionality
+    director_postgresql_package   bacula_director_postgresql_package The name of the package to install the director's postgresql functionality
+    storage_postgresql_package    bacula_storage_postgresql_package The name of the package to install the storage's postgresql functionality
     director_template             bacula_director_template        The ERB template to use for configuring the director instead of the one included with the module
     storage_template              bacula_storage_template         The ERB template to use for configuring the storage daemon instead of the one included with the module
     console_template              bacula_console_template         The ERB template to use for configuring the bconsole instead of the one included with the module

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -155,17 +155,39 @@ class bacula::config {
   }
 
   $storage_mysql_package  = $::bacula_storage_mysql_package ? {
-    undef   => 'bacula-sd-mysql',
+	undef   => $osfamily ? {
+      /(RedHat|Suse)/ => 'bacula-storage-mysql',
+      default         => 'bacula-sd-mysql',
+    },
     default => $::bacula_storage_mysql_package,
   }
 
+  $director_postgresql_package  = $::bacula_director_postgresql_package ? {
+    undef   => 'bacula-director-postgresql',
+    default => $::bacula_director_postgresql_package,
+  }
+
+  $storage_postgresql_package  = $::bacula_storage_postgresql_package ? {
+	undef   => $osfamily ? {
+      /(RedHat|Suse)/ => 'bacula-storage-postgresql',
+      default         => 'bacula-sd-postgresql',
+    },
+    default => $::bacula_storage_postgresql_package,
+  }
+
   $director_sqlite_package = $::bacula_director_sqlite_package ? {
-    undef   => 'bacula-director-sqlite3',
+	undef  => $osfamily ? {
+      /(RedHat|Suse)/ => 'bacula-director-sqlite',
+      default         => 'bacula-director-sqlite3',
+    },
     default => $::bacula_director_sqlite_package,
   }
 
   $storage_sqlite_package = $::bacula_storage_sqlite_package ? {
-    undef   => 'bacula-sd-sqlite3',
+	undef  => $osfamily ? {
+      /(RedHat|Suse)/ => 'bacula-storage-sqlite',
+      default         => 'bacula-sd-sqlite3',
+    },
     default => $::bacula_storage_sqlite_package,
   }
 
@@ -188,10 +210,10 @@ class bacula::config {
     undef   => '',
     default => $::bacula_db_user,
   }
- 
+
   $db_port = $::bacula_db_port ? {
     undef   => '3306',
-    default => $::bacula_db_user,
+    default => $::bacula_db_port,
   }
 
   $db_password = $::bacula_db_password ? {
@@ -209,9 +231,16 @@ class bacula::config {
     default => $::bacula_db_database,
   }
 
-
   #If it's undef, that's fine
   $director_template = $::bacula_director_template
   $storage_template  = $::bacula_storage_template
   $console_template  = $::bacula_console_template
+  
+  $director_service = $::bacula_director_service ? {
+    undef  => $osfamily ? {
+      /(RedHat|Suse)/ => 'bacula-dir',
+      default         => 'bacula-director',
+    },
+    default => $::bacula_director_service,
+  }
 }

--- a/manifests/config/client.pp
+++ b/manifests/config/client.pp
@@ -2,6 +2,7 @@ define bacula::config::client (
    $fileset  = 'Basic:noHome',
    $schedule = 'WeeklyCycle',
    $template = 'bacula/client_config.erb',
+   $director_service = $bacula::config::director_service,
  ) {
 
  if ! is_domain_name($name) {
@@ -11,9 +12,14 @@ define bacula::config::client (
  $name_array = split($name, '[.]')
  $hostname   = $name_array[0]
 
+ $bacula_director_service = $osfamily ? {
+   /(RedHat|Suse)/ => 'bacula-dir',
+   default  => 'bacula-director',
+ }
+
  file { "/etc/bacula/bacula-dir.d/${name}.conf":
    ensure  => file,
    content => template($template),
-   notify  => Service['bacula-director'],
+   notify  => Service["$bacula_director_service"],
  }
 }

--- a/manifests/config/client.pp
+++ b/manifests/config/client.pp
@@ -12,11 +12,6 @@ define bacula::config::client (
  $name_array = split($name, '[.]')
  $hostname   = $name_array[0]
 
- $bacula_director_service = $osfamily ? {
-   /(RedHat|Suse)/ => 'bacula-dir',
-   default  => 'bacula-director',
- }
-
  file { "/etc/bacula/bacula-dir.d/${name}.conf":
    ensure  => file,
    content => template($template),

--- a/manifests/storage.pp
+++ b/manifests/storage.pp
@@ -17,6 +17,8 @@
 #     The package name to install the storage daemon mysql component
 #   $sqlite_package:
 #     The package name to install the storage daemon sqlite component
+#   $postgresql_package:
+#     The package name to install the storage daemon postgresql component
 #   $console_password:
 #     The password for the Console compoenent of the Director service
 #   $template:
@@ -45,6 +47,7 @@ class bacula::storage(
     $storage_package = '',
     $mysql_package,
     $sqlite_package,
+    $postgresql_package,
     $console_password,
     $template = 'bacula/bacula-sd.conf.erb'
   ) {
@@ -57,6 +60,7 @@ class bacula::storage(
   $db_package = $db_backend ? {
     'mysql'  => $mysql_package,
     'sqlite' => $sqlite_package,
+    'postgresql' => $postgresql_package,
   }
 
   # This is necessary because the bacula-common package will


### PR DESCRIPTION
2014-10-04 - Patrick Emer <pemer@afdata.de> - 0.0.3
 - Support for Redhat/Centos distributions
 - Support for postgresql database catalog

If you want to verify my code please test it with this puppet module:
```
node default {
  $varclients = {
    'somenode' => {
      'fileset'  => 'Basic:noHome',
      'schedule' => 'Hourly',
    },
    'node2' => {
      'fileset'  => 'Basic:noHome',
      'schedule' => 'Hourly',
    }
  }
 Postgresql_psql {
   cwd => '/',
 }
 include postgresql::client, postgresql::server
 class { 'bacula':
   is_storage        => true,
   is_director       => true,
   is_client         => true,
   manage_console    => true,
   manage_db         => true,
   db_backend        => 'postgresql',
   db_host           => 'localhost',
   db_user           => 'bacula',
   db_password       => 'bacula',
   db_database       => 'bacula',
   db_port           => '5432',
   director_password => 'xxxxxxxxx',
   console_password  => 'xxxxxxxxx',
   director_server   => 'bacula.domain.com',
   mail_to           => 'bacula-admin@domain.com',
   storage_server    => 'bacula.domain.com',
   clients           => $varclients,
 }
}
```